### PR TITLE
Introduce setup and teardown hooks for tests

### DIFF
--- a/AllTests.c
+++ b/AllTests.c
@@ -4,6 +4,7 @@
 
 CuSuite* CuGetSuite(void);
 CuSuite* CuStringGetSuite(void);
+CuSuite* CuSuiteFrameGetSuite(void);
 
 int RunAllTests(void)
 {
@@ -12,6 +13,7 @@ int RunAllTests(void)
 
 	CuSuiteAddSuite(suite, CuGetSuite());
 	CuSuiteAddSuite(suite, CuStringGetSuite());
+	CuSuiteAddSuite(suite, CuSuiteFrameGetSuite());
 
 	CuSuiteRun(suite);
 	CuSuiteSummary(suite, output);

--- a/AllTests.c
+++ b/AllTests.c
@@ -5,6 +5,7 @@
 CuSuite* CuGetSuite(void);
 CuSuite* CuStringGetSuite(void);
 CuSuite* CuSuiteFrameGetSuite(void);
+CuSuite* CuSuiteChainGetSuite(void);
 
 int RunAllTests(void)
 {
@@ -14,6 +15,7 @@ int RunAllTests(void)
 	CuSuiteAddSuite(suite, CuGetSuite());
 	CuSuiteAddSuite(suite, CuStringGetSuite());
 	CuSuiteAddSuite(suite, CuSuiteFrameGetSuite());
+	CuSuiteAddSuite(suite, CuSuiteChainGetSuite());
 
 	CuSuiteRun(suite);
 	CuSuiteSummary(suite, output);

--- a/CuTest.c
+++ b/CuTest.c
@@ -158,9 +158,13 @@ static void CuFailInternal(CuTest* tc, const char* file, int line, CuString* str
 	CuStringInsert(string, buf, 0);
 
 	tc->failed = 1;
-        free(tc->message);
-        tc->message = CuStringNew();
-        CuStringAppend(tc->message, string->buffer);
+	if (NULL != tc->message) {
+		CuStringAppend(tc->message, "\n");
+	}
+	else {
+		tc->message = CuStringNew();
+	}
+	CuStringAppend(tc->message, string->buffer);
 	if (tc->jumpBuf != 0) longjmp(*(tc->jumpBuf), 0);
 }
 

--- a/CuTest.h
+++ b/CuTest.h
@@ -48,12 +48,15 @@ struct CuTest
 	int ran;
 	CuString *message;
 	jmp_buf *jumpBuf;
+	void *context;
 };
 
 void CuTestInit(CuTest* t, const char* name, TestFunction function);
 CuTest* CuTestNew(const char* name, TestFunction function);
 void CuTestRun(CuTest* tc);
 void CuTestDelete(CuTest *t);
+void *CuTestContextGet(CuTest *tc);
+void CuTestContextSet(CuTest *tc, void *context);
 
 /* Internal versions of assert functions -- use the public versions */
 void CuFail_Line(CuTest* tc, const char* file, int line, const char* message2, const char* message);
@@ -95,17 +98,25 @@ void CuAssertPtrEquals_LineMsg(CuTest* tc,
 
 #define SUITE_ADD_TEST(SUITE,TEST)	CuSuiteAdd(SUITE, CuTestNew(#TEST, TEST))
 
+typedef struct CuTestFrame {
+	void (*setup)(CuTest *tc);
+	void (*teardown)(CuTest *tc);
+}CuTestFrame;
+
 typedef struct
 {
 	int count;
 	CuTest* list[MAX_TEST_CASES];
 	int failCount;
 
+	const CuTestFrame *frame;
+	void *frameContext;
 } CuSuite;
 
-
 void CuSuiteInit(CuSuite* testSuite);
+void CuSuiteInitWithFrame(CuSuite* testSuite, const CuTestFrame *frame, void *frameContext);
 CuSuite* CuSuiteNew(void);
+CuSuite* CuSuiteNewWithFrame(const CuTestFrame *frame, void *frameContext);
 void CuSuiteDelete(CuSuite *testSuite);
 void CuSuiteAdd(CuSuite* testSuite, CuTest *testCase);
 void CuSuiteAddSuite(CuSuite* testSuite, CuSuite* testSuite2);

--- a/CuTest.h
+++ b/CuTest.h
@@ -103,7 +103,7 @@ typedef struct CuTestFrame {
 	void (*teardown)(CuTest *tc);
 }CuTestFrame;
 
-typedef struct
+typedef struct CuSuite
 {
 	int count;
 	CuTest* list[MAX_TEST_CASES];
@@ -111,6 +111,8 @@ typedef struct
 
 	const CuTestFrame *frame;
 	void *frameContext;
+
+	struct CuSuite *next;
 } CuSuite;
 
 void CuSuiteInit(CuSuite* testSuite);

--- a/CuTestTest.c
+++ b/CuTestTest.c
@@ -170,24 +170,30 @@ void TestCuTestInit(CuTest *tc)
 
 void TestCuAssert(CuTest* tc)
 {
+	CuTest tc1;
+	CuTestInit(&tc1, "MyTest", TestPasses);
+	CuAssert(&tc1, "test 1", 5 == 4 + 1);
+	CuAssertTrue(tc, !tc1.failed);
+	CuAssertTrue(tc, tc1.message == NULL);
+
 	CuTest tc2;
 	CuTestInit(&tc2, "MyTest", TestPasses);
-
-	CuAssert(&tc2, "test 1", 5 == 4 + 1);
-	CuAssertTrue(tc, !tc2.failed);
-        CuAssertTrue(tc, tc2.message == NULL);
-
 	CuAssert(&tc2, "test 2", 0);
 	CuAssertTrue(tc, tc2.failed);
 	CompareAsserts(tc, "CuAssert didn't fail", "test 2", tc2.message);
 
-	CuAssert(&tc2, "test 3", 1);
-	CuAssertTrue(tc, tc2.failed);
-	CompareAsserts(tc, "CuAssert didn't fail", "test 2", tc2.message);
+	CuTest tc3;
+	CuTestInit(&tc3, "MyTest", TestPasses);
+	CuAssert(&tc3, "test 2", 0);
+	CuAssert(&tc3, "test 3", 1);
+	CuAssertTrue(tc, tc3.failed);
+	CompareAsserts(tc, "CuAssert didn't fail", "test 2", tc3.message);
 
-	CuAssert(&tc2, "test 4", 0);
-	CuAssertTrue(tc, tc2.failed);
-	CompareAsserts(tc, "CuAssert didn't fail", "test 4", tc2.message);
+	CuTest tc4;
+	CuTestInit(&tc4, "MyTest", TestPasses);
+	CuAssert(&tc4, "test 4", 0);
+	CuAssertTrue(tc, tc4.failed);
+	CompareAsserts(tc, "CuAssert didn't fail", "test 4", tc4.message);
 
 }
 
@@ -528,18 +534,21 @@ void TestFail(CuTest* tc)
 void TestAssertStrEquals(CuTest* tc)
 {
 	jmp_buf buf;
-	CuTest *tc2 = CuTestNew("TestAssertStrEquals", zTestFails);
 
 	const char* expected = "expected <hello> but was <world>";
 	const char *expectedMsg = "some text: expected <hello> but was <world>";
 
-	tc2->jumpBuf = &buf;
+	CuTest *tc1 = CuTestNew("TestAssertStrEquals", zTestFails);
+	tc1->jumpBuf = &buf;
 	if (setjmp(buf) == 0)
 	{
-		CuAssertStrEquals(tc2, "hello", "world");
+		CuAssertStrEquals(tc1, "hello", "world");
 	}
-	CuAssertTrue(tc, tc2->failed);
-	CompareAsserts(tc, "CuAssertStrEquals failed", expected, tc2->message);
+	CuAssertTrue(tc, tc1->failed);
+	CompareAsserts(tc, "CuAssertStrEquals failed", expected, tc1->message);
+
+	CuTest *tc2 = CuTestNew("TestAssertStrEquals", zTestFails);
+	tc2->jumpBuf = &buf;
 	if (setjmp(buf) == 0)
 	{
 		CuAssertStrEquals_Msg(tc2, "some text", "hello", "world");
@@ -571,18 +580,21 @@ void TestAssertStrEquals_NULL(CuTest* tc)
 void TestAssertStrEquals_FailNULLStr(CuTest* tc)
 {
 	jmp_buf buf;
-	CuTest *tc2 = CuTestNew("TestAssertStrEquals_FailNULLStr", zTestFails);
 
 	const char* expected = "expected <hello> but was <NULL>";
 	const char *expectedMsg = "some text: expected <hello> but was <NULL>";
 
-	tc2->jumpBuf = &buf;
+	CuTest *tc1 = CuTestNew("TestAssertStrEquals_FailNULLStr", zTestFails);
+	tc1->jumpBuf = &buf;
 	if (setjmp(buf) == 0)
 	{
-		CuAssertStrEquals(tc2, "hello", NULL);
+		CuAssertStrEquals(tc1, "hello", NULL);
 	}
-	CuAssertTrue(tc, tc2->failed);
-	CompareAsserts(tc, "CuAssertStrEquals_FailNULLStr failed", expected, tc2->message);
+	CuAssertTrue(tc, tc1->failed);
+	CompareAsserts(tc, "CuAssertStrEquals_FailNULLStr failed", expected, tc1->message);
+
+	CuTest *tc2 = CuTestNew("TestAssertStrEquals_FailNULLStr", zTestFails);
+	tc2->jumpBuf = &buf;
 	if (setjmp(buf) == 0)
 	{
 		CuAssertStrEquals_Msg(tc2, "some text", "hello", NULL);
@@ -594,18 +606,20 @@ void TestAssertStrEquals_FailNULLStr(CuTest* tc)
 void TestAssertStrEquals_FailStrNULL(CuTest* tc)
 {
 	jmp_buf buf;
-	CuTest *tc2 = CuTestNew("TestAssertStrEquals_FailStrNULL", zTestFails);
-
 	const char* expected = "expected <NULL> but was <hello>";
 	const char *expectedMsg = "some text: expected <NULL> but was <hello>";
 
-	tc2->jumpBuf = &buf;
+	CuTest *tc1 = CuTestNew("TestAssertStrEquals_FailStrNULL", zTestFails);
+	tc1->jumpBuf = &buf;
 	if (setjmp(buf) == 0)
 	{
-		CuAssertStrEquals(tc2, NULL, "hello");
+		CuAssertStrEquals(tc1, NULL, "hello");
 	}
-	CuAssertTrue(tc, tc2->failed);
-	CompareAsserts(tc, "CuAssertStrEquals_FailStrNULL failed", expected, tc2->message);
+	CuAssertTrue(tc, tc1->failed);
+	CompareAsserts(tc, "CuAssertStrEquals_FailStrNULL failed", expected, tc1->message);
+
+	CuTest *tc2 = CuTestNew("TestAssertStrEquals_FailStrNULL", zTestFails);
+	tc2->jumpBuf = &buf;
 	if (setjmp(buf) == 0)
 	{
 		CuAssertStrEquals_Msg(tc2, "some text", NULL, "hello");
@@ -617,16 +631,19 @@ void TestAssertStrEquals_FailStrNULL(CuTest* tc)
 void TestAssertIntEquals(CuTest* tc)
 {
 	jmp_buf buf;
-	CuTest *tc2 = CuTestNew("TestAssertIntEquals", zTestFails);
+	CuTest *tc1 = CuTestNew("TestAssertIntEquals", zTestFails);
 	const char* expected = "expected <42> but was <32>";
 	const char* expectedMsg = "some text: expected <42> but was <32>";
-	tc2->jumpBuf = &buf;
+	tc1->jumpBuf = &buf;
 	if (setjmp(buf) == 0)
 	{
-		CuAssertIntEquals(tc2, 42, 32);
+		CuAssertIntEquals(tc1, 42, 32);
 	}
-	CuAssertTrue(tc, tc2->failed);
-	CompareAsserts(tc, "CuAssertIntEquals failed", expected, tc2->message);
+	CuAssertTrue(tc, tc1->failed);
+	CompareAsserts(tc, "CuAssertIntEquals failed", expected, tc1->message);
+
+	CuTest *tc2 = CuTestNew("TestAssertIntEquals", zTestFails);
+	tc2->jumpBuf = &buf;
 	if (setjmp(buf) == 0)
 	{
 		CuAssertIntEquals_Msg(tc2, "some text", 42, 32);
@@ -663,13 +680,15 @@ void TestAssertDblEquals(CuTest* tc)
 	}
 	CuAssertTrue(tc, tc2->failed);
 	CompareAsserts(tc, "CuAssertDblEquals failed", expected, tc2->message);
-	tc2->jumpBuf = &buf;
+
+	CuTest *tc3 = CuTestNew("TestAssertDblEquals", zTestFails);
+	tc3->jumpBuf = &buf;
 	if (setjmp(buf) == 0)
 	{
-		CuAssertDblEquals_Msg(tc2, "some text", x, y, 0.001);
+		CuAssertDblEquals_Msg(tc3, "some text", x, y, 0.001);
 	}
-	CuAssertTrue(tc, tc2->failed);
-	CompareAsserts(tc, "CuAssertDblEquals failed", expectedMsg, tc2->message);
+	CuAssertTrue(tc, tc3->failed);
+	CompareAsserts(tc, "CuAssertDblEquals failed", expectedMsg, tc3->message);
 }
 
 /*-------------------------------------------------------------------------*
@@ -763,7 +782,7 @@ static void FrameMockSetup(CuTest *tc) {
 
 	TestPhaseRecord(&TestMockData.tracker, SETUP);
 
-	CuAssert(tc, "Have to fail", !fail);
+	CuAssert(tc, "Setup has to fail", !fail);
 	TestMockData.setupContinuedAfterAssert = true;
 }
 
@@ -774,7 +793,7 @@ static void FrameMockTest(CuTest *tc) {
 	TestPhaseRecord(&TestMockData.tracker, TEST);
 	TestMockData.ContextPassed = CuTestContextGet(tc);
 
-	CuAssert(tc, "Have to fail", !fail);
+	CuAssert(tc, "Test has to fail", !fail);
 	TestMockData.testContinuedAfterAssert = true;
 }
 
@@ -784,7 +803,7 @@ static void FrameMockTearDown(CuTest *tc) {
 
 	TestPhaseRecord(&TestMockData.tracker, TEARDOWN);
 
-	CuAssert(tc, "Have to fail", !fail);
+	CuAssert(tc, "Teardown has to fail", !fail);
 	TestMockData.teardownContinuedAfterAssert = true;
 }
 
@@ -880,6 +899,27 @@ static void TestSuiteTeardownIsExecutedIfTestFails(CuTest *tc) {
 	CuAssertIntEquals(tc, TEST, tracker->TestSequence[1]);
 	CuAssertIntEquals(tc, TEARDOWN, tracker->TestSequence[2]);
 	TestPhaseNoMoreEventsFrom(tc, tracker, 3);
+}
+
+static void TestSuiteFailingTestMessageIsPreservedWhenTeardownFails(CuTest *tc) {
+	int context = 0;
+	TestMockDataInit();
+	CuSuite* uut = CuSuiteNewWithFrame(&FrameMock, &context);
+
+	SUITE_ADD_TEST(uut, FrameMockTest);
+
+	TestMockData.testShallFail = true;
+	TestMockData.teardownShallFail = true;
+
+	CuSuiteRun(uut);
+
+	char *message = uut->list[0]->message->buffer;
+	char *testFailMsg = strstr(message, "Test has to fail\n");
+	char *teardownFailMsg = strstr(message, "Teardown has to fail");
+
+	CuAssertPtrNotNullMsg(tc, "Test fail message not found", testFailMsg);
+	CuAssertPtrNotNullMsg(tc, "Teardown fail message not found", teardownFailMsg);
+	CuAssert(tc, "Message order correct", testFailMsg < teardownFailMsg);
 }
 
 static void TestSuiteContextPassedToCuTest(CuTest *tc) {
@@ -1001,6 +1041,7 @@ CuSuite* CuSuiteFrameGetSuite(void) {
 	SUITE_ADD_TEST(suite, TestSuiteTestFailsIfSetupFails);
 	SUITE_ADD_TEST(suite, TestSuiteTestFailsIfTeardownFails);
 	SUITE_ADD_TEST(suite, TestSuiteTeardownIsExecutedIfTestFails);
+	SUITE_ADD_TEST(suite, TestSuiteFailingTestMessageIsPreservedWhenTeardownFails);
 	SUITE_ADD_TEST(suite, TestSuiteContextPassedToCuTest);
 	SUITE_ADD_TEST(suite, TestSuiteSetupInterruptsUponFailedAssert);
 	SUITE_ADD_TEST(suite, TestSuiteTestInterruptsUponFailedAssert);

--- a/README
+++ b/README
@@ -154,6 +154,13 @@ to form a CuSuite. CuSuites can hold CuTests or other CuSuites.
 AllTests.c collects all the CuSuites in the program into a single
 CuSuite which it then runs as a single CuSuite.
 
+A CuSuite also allows you to execute setup (for preparations) and 
+teardown (for cleanup) procedures that are shared among all tests
+grouped in the respective suite. This is typically used to create
+and/or setup your unit under test and simplifies the actual test
+to be executed. A typical use is shown below in the section 
+"USING THE SETUP-TEARDOWN FACILITY". 
+
 The project is open source so feel free to take a peek under the
 hood at the CuTest.c file to see how it works. CuTestTest.c
 contains tests for CuTest.c. So CuTest tests itself.
@@ -199,6 +206,91 @@ directory and generate the code to run all the tests contained in
 them. Using this script you don't have to worry about writing
 AllTests.c or dealing with any of the other suite code.
 
+USING SETUP-TEARDOWN FACILITY
+Virtually every test should be written in a setup-test-assert-
+tearodwn sequence. Although test and assertion vary depending on 
+the concrete test cases, it's quite common, that a group of tests
+have a common starting point or common needs that have to be 
+setup before the test is executed. Those can be grouped in a suite
+where they share their setup and teardown code. 
+
+Below is a code example showing how this can be done based on an
+assumed vector arithmetics library that is supposed to be tested.
+
+For the demonstration it is assumed, that a Point.h & Point.c 
+file exist implementing some vector arithmetics:    
+    typedef struct PointXY {
+      int x;
+      int y;
+    }PointXY;
+    
+    void POINT_add(PointXY *result, const PointXY *a, const PointXY *b) {
+        ...
+    }
+    
+    void POINT_sub(PointXY *result, const PointXY *a, const PointXY *b) {
+        ...
+    }
+
+In order to test those functions, your PointTest.c would look as follows:
+    #include "CuTest.h"
+    
+    static void PointSetup(CuTest *tc) {
+        PointXY *uut = calloc(2, sizeof PointXY);
+        uut[0].x = 1;
+        uut[0].y = -3;
+
+        uut[1].x = 5;
+        uut[1].y = -7;
+        CuTestContextSet(tc, uut);
+    }
+    
+    static void PointTeardown(CuTest *tc) {
+        PointXY *uut = CuTestContextGet(tc);
+        CuTestContextSet(tc, NULL);
+        free(uut);
+        uut = NULL;
+    }
+
+    static const CuTestFrame PointTestFrame = {
+        .setup = PointSetup,
+        .teardown = PointTeardown,
+    };
+    
+    void TestVectorAddition(CuTest *tc) {
+        PointXY result;
+        PointXY *args = CuTestContextGet(tc);
+        
+        POINT_add(&result, &(args[0]), &(args[1]));
+        
+        CuAssertIntEquals(tc, 6, result.x);
+        CuAssertIntEquals(tc, -10, result.y);
+    }
+    
+    void TestVectorSubstract(CuTest *tc) {
+        PointXY result;
+        PointXY *args = CuTestContextGet(tc);
+        
+        POINT_sub(&result, &(args[0]), &(args[1]));
+        
+        CuAssertIntEquals(tc, -4, result.x);
+        CuAssertIntEquals(tc, 4, result.y);
+    }
+   
+    CuSuite* PointTestSuiteGet() {
+        CuSuite* suite = CuSuiteNewWithFrame(&PointTestFrame, NULL);
+        
+        SUITE_ADD_TEST(suite, TestVectorAddition);
+        SUITE_ADD_TEST(suite, TestVectorSubstract);
+        
+        return suite;
+    }
+
+The second parameter for CuSuiteNewWithFrame can be used to preset 
+the context to the test respectively the setup function that is called.
+
+A context modified during test execution is always brought back to the
+suite. Hence be careful to not introduce test interdependencies.
 
 CREDITS
 


### PR DESCRIPTION
In order to simplify creation of multiple tests (partially) sharing the same setup procedures, a possibility to hook into the test execution is introduced: Hooks for setting up the test (before the test executes) and tearing down the setup after the test executed.

I've TDDed the changes and thus extended the existing tests. However I didn't spend too much time yet for thinking about refactoring the test code. Still I wanted to float that change over to you as a request for comment, @ennorehling.